### PR TITLE
Feat : 대출 심사 조회 기능 구현

### DIFF
--- a/src/main/java/com/loan/loan/controller/JudgementController.java
+++ b/src/main/java/com/loan/loan/controller/JudgementController.java
@@ -5,10 +5,7 @@ import com.loan.loan.dto.JudgmentDTO.Response;
 import com.loan.loan.dto.ResponseDTO;
 import com.loan.loan.service.JudgementServiceImpl;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,5 +17,15 @@ public class JudgementController extends AbstractController {
     @PostMapping
     public ResponseDTO<Response> create(@RequestBody Request request) {
         return ok(judgementService.create(request));
+    }
+
+    @GetMapping("/{judgementId}")
+    public ResponseDTO<Response> get(@PathVariable Long judgementId) {
+        return ok(judgementService.get(judgementId));
+    }
+
+    @GetMapping("/applications/{applicationId}")
+    public ResponseDTO<Response> getJudgementOfApplication(@PathVariable Long applicationId) {
+        return ok(judgementService.getJudgementOfApplication(applicationId));
     }
 }

--- a/src/main/java/com/loan/loan/repository/JudgementRepository.java
+++ b/src/main/java/com/loan/loan/repository/JudgementRepository.java
@@ -4,6 +4,10 @@ import com.loan.loan.domain.Judgment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface JudgementRepository extends JpaRepository<Judgment, Long> {
+
+    Optional<Judgment> findByApplicationId(Long applicationId);
 }

--- a/src/main/java/com/loan/loan/service/JudgementServiceImpl.java
+++ b/src/main/java/com/loan/loan/service/JudgementServiceImpl.java
@@ -35,6 +35,20 @@ public class JudgementServiceImpl implements JudgmentService {
         return modelMapper.map(saved, Response.class);
     }
 
+    @Override
+    public Response get(Long judgementId) {
+        Judgment judgment = judgementRepository.findById(judgementId).orElseThrow(() -> {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        });
+
+        return modelMapper.map(judgment, Response.class);
+    }
+
+    @Override
+    public Response getJudgementOfApplication(Long applicationId) {
+        return null;
+    }
+
     private boolean isPresentApplication(Long applicationId) {
         return applicationRepository.findById(applicationId).isPresent();
     }

--- a/src/main/java/com/loan/loan/service/JudgementServiceImpl.java
+++ b/src/main/java/com/loan/loan/service/JudgementServiceImpl.java
@@ -46,7 +46,15 @@ public class JudgementServiceImpl implements JudgmentService {
 
     @Override
     public Response getJudgementOfApplication(Long applicationId) {
-        return null;
+        if (!isPresentApplication(applicationId)) {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        }
+
+        Judgment judgment = judgementRepository.findByApplicationId(applicationId).orElseThrow(() -> {
+            throw new BaseException(ResultType.SYSTEM_ERROR); // 신청 건에 대해서 심사가 완료되지 않은 경우
+        });
+
+        return modelMapper.map(judgment, Response.class);
     }
 
     private boolean isPresentApplication(Long applicationId) {

--- a/src/main/java/com/loan/loan/service/JudgmentService.java
+++ b/src/main/java/com/loan/loan/service/JudgmentService.java
@@ -6,4 +6,8 @@ import com.loan.loan.dto.JudgmentDTO.Response;
 public interface JudgmentService {
 
     Response create(Request request);
+
+    Response get(Long judgementId);
+
+    Response getJudgementOfApplication(Long applicationId);
 }

--- a/src/test/java/com/loan/loan/service/JudgementServiceTest.java
+++ b/src/test/java/com/loan/loan/service/JudgementServiceTest.java
@@ -55,4 +55,18 @@ public class JudgementServiceTest {
         assertThat(actual.getApplicationId()).isSameAs(entity.getApplicationId());
         assertThat(actual.getApprovalAmount()).isSameAs(entity.getApprovalAmount());
     }
+
+    @Test
+    void Should_ReturnResponseOfExistJudgmentEntity_When_RequestExistJudgment() {
+
+        Judgment entity = Judgment.builder()
+                .judgmentId(1L)
+                .build();
+
+        when(judgementRepository.findById(1L)).thenReturn(Optional.ofNullable(entity));
+
+        Response actual = judgementService.get(1L);
+
+        assertThat(actual.getJudgmentId()).isSameAs(1L);
+    }
 }

--- a/src/test/java/com/loan/loan/service/JudgementServiceTest.java
+++ b/src/test/java/com/loan/loan/service/JudgementServiceTest.java
@@ -69,4 +69,23 @@ public class JudgementServiceTest {
 
         assertThat(actual.getJudgmentId()).isSameAs(1L);
     }
+
+    @Test
+    void Should_ReturnResponseOfExistJudgementEntity_When_RequestExistApplicationId() {
+
+        Judgment judgementEntity = Judgment.builder()
+                .judgmentId(1L)
+                .build();
+
+        Application applicationEntity = Application.builder()
+                .applicationId(1L)
+                .build();
+
+        when(applicationRepository.findById(1L)).thenReturn(Optional.ofNullable(applicationEntity));
+        when(judgementRepository.findByApplicationId(1L)).thenReturn(Optional.ofNullable(judgementEntity));
+
+        Response actual = judgementService.getJudgementOfApplication(1L);
+
+        assertThat(actual.getJudgmentId()).isSameAs(1L);
+    }
 }


### PR DESCRIPTION
대출 심사 건에 대한 조회 기능을 구현하였다.
대출 심사 조회는 대출 심사 정보를 통한 조회와 고객이 신청한 대출 신청 정보를 통한 조회 두 가지를 구현하였다.
추가적으로 두 가지의 대출 심사 정보 조회 기능의 비즈니스 로직에 대한 테스트케이스를 작성하였다.