### PR TITLE
Feat : 대출 심사 정보 수정 기능 구현

### DIFF
--- a/src/main/java/com/loan/loan/controller/JudgementController.java
+++ b/src/main/java/com/loan/loan/controller/JudgementController.java
@@ -28,4 +28,9 @@ public class JudgementController extends AbstractController {
     public ResponseDTO<Response> getJudgementOfApplication(@PathVariable Long applicationId) {
         return ok(judgementService.getJudgementOfApplication(applicationId));
     }
+
+    @PutMapping("/{judgmentId}")
+    public ResponseDTO<Response> update(@PathVariable Long judgmentId, @RequestBody Request request) {
+        return ok(judgementService.update(judgmentId, request));
+    }
 }

--- a/src/main/java/com/loan/loan/service/JudgementServiceImpl.java
+++ b/src/main/java/com/loan/loan/service/JudgementServiceImpl.java
@@ -57,6 +57,20 @@ public class JudgementServiceImpl implements JudgmentService {
         return modelMapper.map(judgment, Response.class);
     }
 
+    @Override
+    public Response update(Long judgmentId, Request request) {
+        Judgment judgment = judgementRepository.findById(judgmentId).orElseThrow(() -> {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        });
+
+        judgment.setName(request.getName());
+        judgment.setApprovalAmount(request.getApprovalAmount());
+
+        judgementRepository.save(judgment);
+
+        return modelMapper.map(judgment, Response.class);
+    }
+
     private boolean isPresentApplication(Long applicationId) {
         return applicationRepository.findById(applicationId).isPresent();
     }

--- a/src/main/java/com/loan/loan/service/JudgmentService.java
+++ b/src/main/java/com/loan/loan/service/JudgmentService.java
@@ -10,4 +10,6 @@ public interface JudgmentService {
     Response get(Long judgementId);
 
     Response getJudgementOfApplication(Long applicationId);
+
+    Response update(Long judgmentId, Request request);
 }

--- a/src/test/java/com/loan/loan/service/JudgementServiceTest.java
+++ b/src/test/java/com/loan/loan/service/JudgementServiceTest.java
@@ -88,4 +88,27 @@ public class JudgementServiceTest {
 
         assertThat(actual.getJudgmentId()).isSameAs(1L);
     }
+
+    @Test
+    void Should_ReturnUpdatedResponseOfExistJudgmentEntity_When_RequestUpdateExistJudgementInfo() {
+        Request request = Request.builder()
+                .name("Member Lee")
+                .approvalAmount(BigDecimal.valueOf(10000000))
+                .build();
+
+        Judgment entity = Judgment.builder()
+                .judgmentId(1L)
+                .name("Member Kim")
+                .approvalAmount(BigDecimal.valueOf(5000000))
+                .build();
+
+        when(judgementRepository.findById(1L)).thenReturn(Optional.ofNullable(entity));
+        when(judgementRepository.save(any(Judgment.class))).thenReturn(entity);
+
+        Response actual = judgementService.update(1L, request);
+
+        assertThat(actual.getJudgmentId()).isSameAs(1L);
+        assertThat(actual.getName()).isSameAs(request.getName());
+        assertThat(actual.getApprovalAmount()).isSameAs(request.getApprovalAmount());
+    }
 }


### PR DESCRIPTION
대출 심사 정보 수정 기능을 구현하였다.
대출 심사 정보 수정에 대해서는 심사 엔티티의 ID와 같은 값은 수정되면 안되므로
심사 정보 수정에서 별도의 request 와 response가 필요하지만
해당 프로젝트의 경우 공부를 위해서 간단하게 진행하는 프로젝트이므로
기존에 작성한 request와 response를 통해서 구현할 수 있는 범위로만 구현하였다.
추가적으로 대출 심사 정보 수정 기능의 비즈니스 로직에 대한 테스트케이스를 작성하였다.