### PR TITLE
Feat : 대출 심사 삭제 기능 구현

### DIFF
--- a/src/main/java/com/loan/loan/controller/JudgementController.java
+++ b/src/main/java/com/loan/loan/controller/JudgementController.java
@@ -33,4 +33,10 @@ public class JudgementController extends AbstractController {
     public ResponseDTO<Response> update(@PathVariable Long judgmentId, @RequestBody Request request) {
         return ok(judgementService.update(judgmentId, request));
     }
+
+    @DeleteMapping("/{judgmentId}")
+    public ResponseDTO<Void> delete(@PathVariable Long judgmentId) {
+        judgementService.delete(judgmentId);
+        return ok();
+    }
 }

--- a/src/main/java/com/loan/loan/service/JudgementServiceImpl.java
+++ b/src/main/java/com/loan/loan/service/JudgementServiceImpl.java
@@ -71,6 +71,17 @@ public class JudgementServiceImpl implements JudgmentService {
         return modelMapper.map(judgment, Response.class);
     }
 
+    @Override
+    public void delete(Long judgmentId) {
+        Judgment judgment = judgementRepository.findById(judgmentId).orElseThrow(() -> {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        });
+
+        judgment.setIsDeleted(true);
+
+        judgementRepository.save(judgment);
+    }
+
     private boolean isPresentApplication(Long applicationId) {
         return applicationRepository.findById(applicationId).isPresent();
     }

--- a/src/main/java/com/loan/loan/service/JudgmentService.java
+++ b/src/main/java/com/loan/loan/service/JudgmentService.java
@@ -12,4 +12,6 @@ public interface JudgmentService {
     Response getJudgementOfApplication(Long applicationId);
 
     Response update(Long judgmentId, Request request);
+
+    void delete(Long judgmentId);
 }

--- a/src/test/java/com/loan/loan/service/JudgementServiceTest.java
+++ b/src/test/java/com/loan/loan/service/JudgementServiceTest.java
@@ -111,4 +111,18 @@ public class JudgementServiceTest {
         assertThat(actual.getName()).isSameAs(request.getName());
         assertThat(actual.getApprovalAmount()).isSameAs(request.getApprovalAmount());
     }
+
+    @Test
+    void Should_DeletedJudgmentEntity_When_RequestDeleteExistJudgementInfo() {
+
+        Judgment entity = Judgment.builder()
+                .judgmentId(1L)
+                .build();
+
+        when(judgementRepository.findById(1L)).thenReturn(Optional.ofNullable(entity));
+        when(judgementRepository.save(any(Judgment.class))).thenReturn(entity);
+        judgementService.delete(1L);
+
+        assertThat(entity.getIsDeleted()).isTrue();
+    }
 }


### PR DESCRIPTION
대출 심사 삭제 기능 구현에 대해서는 기존의 작성한 대출 신청 정보 삭제와 약관 삭제와 같이
실제로 삭제하지 않고 'is_deleted' 속성을 true로 변경하는 'Soft Delete' 로 구현하여,
추후에 배치를 통해서 일괄적으로 삭제하는 등의 방법을 사용하도록 한다.
추가적으로 대출 심사 삭제 기능의 비즈니스 로직에 대한 테스트케이스를 작성하였다.