### PR TITLE
Feat :  대출 집행 기능 개발을 위한 도메인 테이블 정의

### DIFF
--- a/src/main/java/com/loan/loan/domain/Balance.java
+++ b/src/main/java/com/loan/loan/domain/Balance.java
@@ -1,0 +1,31 @@
+package com.loan.loan.domain;
+
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+import java.math.BigDecimal;
+
+@Entity
+@Setter
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@DynamicInsert
+@DynamicUpdate
+@Where(clause = "is_deleted=false")
+public class Balance extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long balanceId;
+
+    @Column(columnDefinition = "bigint NOT NULL COMMENT '신청 ID'")
+    private Long applicationId;
+
+    @Column(columnDefinition = "decimal(15,2) NOT NULL COMMENT '잔여 대출 금액'")
+    private BigDecimal balance;
+}

--- a/src/main/java/com/loan/loan/domain/Entry.java
+++ b/src/main/java/com/loan/loan/domain/Entry.java
@@ -1,0 +1,31 @@
+package com.loan.loan.domain;
+
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+import java.math.BigDecimal;
+
+@Entity
+@Setter
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@DynamicInsert
+@DynamicUpdate
+@Where(clause = "is_deleted=false")
+public class Entry extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long entryId;
+
+    @Column(columnDefinition = "bigint NOT NULL COMMENT '신청 ID'")
+    private Long applicationId;
+
+    @Column(columnDefinition = "decimal(15,2) NOT NULL COMMENT '집행 금액'")
+    private BigDecimal entryAmount;
+}


### PR DESCRIPTION
고객이 등록한 대출 신청 건에 대해서 계약 성사 이후에 대출 집행 기능을 구현하기 위해서
대출 집행 테이블과 대출 잔여 잔고 테이블을 정의하였다.

실제 대출 기능에 대해서는 좀 더 복잡하게 테이블이 정의되겠지만 공부를 위한 프로젝트이므로
대출 집행과 잔고 테이블에 대해서는 고객이 등록한 대출 신청 ID와 연계되도록만 하였다.