### PR TITLE
Feat : JIB를 통한 Docker 이미지 생성 및 Database 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.1'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+    id 'com.google.cloud.tools.jib' version '3.2.0'
 }
 
 group = 'com.loan'
@@ -13,6 +14,28 @@ java {
 
 repositories {
     mavenCentral()
+}
+
+jib {
+    // 어떠한 base image를 기준으로 내가 만든 application에 대한 image를 생성할 것인지 정의
+    from {
+        image = "openjdk:11-jre-slim"
+    }
+    to {
+        image = 'fintech-loan'
+        tags = ['0.0.1']
+    }
+    container {
+        // fintech-loan 서버에서 class path 를 정의
+        mainClass = 'com.loan.loan.LoanApplication'
+        creationTime = 'USE_CURRENT_TIMESTAMP'
+        format = 'OCI'
+        volumes = ['/var/tmp']
+        // class path 를 같이 지정 해주어야함 -> 우리가 build 한 spring boot 의 class path 명시한다고 생각
+        entrypoint = ['java'
+                      , '-cp', '/app/resources:/app/classes:/app/libs/*'
+        , 'com.loan.loan.LoanApplication']
+    }
 }
 
 dependencies {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,10 +2,11 @@ server:
   port: 8080
 spring:
   datasource:
-    driverClassName: org.h2.Driver
-    url: jdbc:h2:mem:testdb
-    username: sa
-    password:
+    driverClassName: com.mysql.cj.jdbc.Driver
+#    docker container 내부에 localhost 를 바라볼 수 있도록 설정
+    url: jdbc:mysql://host.docker.internal:3306/loan?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+    username: root
+    password: 1234
   jpa:
     hibernate:
       ddl-auto: create
@@ -15,11 +16,8 @@ spring:
         show_sql: true
       naming:
         physical-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
-    database-platform: org.hibernate.dialect.H2Dialect
-  h2:
-    console:
-      path: /h2-console
-      enabled: true
+    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
+    database: mysql
   servlet:
     multipart:
       max-file-size: 10MB


### PR DESCRIPTION
개발한 서버를 JIB 를 사용하여 Docker 이미지 생성 및 빌드를 통해서 배포하기 위해
'build.gradle' 에 JIB 와 관련된 설정 정보들을 추가하였다.

추가적으로 개발을 수행하면서 기존에 사용하던 Database를  H2에서 Mysql로 변경하였으며,
기존에 사용하는 'jdbc:mysql://localhost:3306' 과 같은 url 은 Docker Container 내부에서의 로컬과 맞지 않기 때문에
'jdbc:mysql://host.docker.internal.3306' 과 같은 url 로 지정해줌으로써 Docker Container 내부의 localhost 에서 MySQL 을 사용할 수 있도록 하였다.